### PR TITLE
Remove Mandatory Doxxing | Article 41

### DIFF
--- a/CHARTER.md
+++ b/CHARTER.md
@@ -167,11 +167,6 @@ A council can vote to remove any of its council members with a two-thirds majori
 ### Article 40
 A council’s budget will be streamed wherever possible, meaning that the funds are released continuously over a predetermined period of time.
 
-### Article 41
-Each council is responsible for coming up with their own disclosure process prior to being ratified by ATOM stakers.
-
-> We will need to think hard about how we can add assurances around one person one council, while remaining as anon friendly as possible. What level of identification is acceptable?
-
 ## Chapter 5. Allocator DAOs
 
 ### Article 42 


### PR DESCRIPTION
Visa and SWIFT work fine for thoze interested in surrendering their privacy to participate in financial systems.

The interchain posits an opportunity to break free from a political past where representatives can be threatened and bribed to elicit results, where election outcomes can be determined by candidates' height, and where identity is bound by legal jurisdiction. 

Alternatively, councils should hold their members to a rigid standard of Proof of Productivity. That is, if a council member cannot produce enough productive output for the council to prove that they are not a sybil member, the council should assume they are a sybil member regardless of their level of disclosure and remove them from the council.