### PR TITLE
Update Number of Tranches & Set Issuance Interval | Articles 21 & 22

### DIFF
--- a/CHARTER.md
+++ b/CHARTER.md
@@ -101,7 +101,7 @@ The purpose of the Treasury is to support the maintenance of R&D excellence in t
 The Treasury is initially capitalized through issuance in ten tranches of 4M ATOM each.
 
 ### Article 22
-ATOM stakers must approve each tranche (where the issuance of the tranche is implemented as a governance approved software upgrade or through an in-protocol mechanism which requires governance approval). There must be a minimum interval of 8 months between each successful proposal. No more than one tranche may be issued within a calendar year.
+ATOM stakers must approve each tranche (where the issuance of the tranche is implemented as a governance approved software upgrade or through an in-protocol mechanism which requires governance approval). No more than one tranche may be issued within a calendar year.
 
 ### Article 23
 An Assembly proposal can request that a portion of the Treasury flow back to the Distribution module. The proposal may not ask for more than 10% of the value of the Treasury, and there must be a minimum interval of 1 year between such successful proposals.

--- a/CHARTER.md
+++ b/CHARTER.md
@@ -98,10 +98,10 @@ A fraction of revenues from the distribution module are diverted to the Communit
 The purpose of the Treasury is to support the maintenance of R&D excellence in the Cosmos Hub and its related technologies, and to support special initiatives that increase adoption, growth, and capitalization of the ATOM economic zone, including public works and opportunities for expansion, turning ATOM into the preferred interchain reserve asset.
 
 ### Article 21
-The Treasury is initially capitalized through issuance in twelve tranches of 4M ATOM each.
+The Treasury is initially capitalized through issuance in ten tranches of 4M ATOM each.
 
 ### Article 22
-ATOM stakers must approve each tranche (where the issuance of the tranche is implemented as a governance approved software upgrade or through an in-protocol mechanism which requires governance approval).
+ATOM stakers must approve each tranche (where the issuance of the tranche is implemented as a governance approved software upgrade or through an in-protocol mechanism which requires governance approval). There must be a minimum interval of 8 months between each successful proposal. No more than one tranche may be issued within a calendar year.
 
 ### Article 23
 An Assembly proposal can request that a portion of the Treasury flow back to the Distribution module. The proposal may not ask for more than 10% of the value of the Treasury, and there must be a minimum interval of 1 year between such successful proposals.


### PR DESCRIPTION
Article 21: Change number of tranches from 12 to 10 to match whitepaper v1.2.

Article 22: Set a minimum issuance interval of 8-12 months. This is a guardrail for a more steady funding schedule, while allowing for some flexibility. Though it is unlikely that we would have multiple treasury funding proposals over a short timespan, this change would assuage the concerns of the community regarding "inflation shock".