### PR TITLE
Give Assembly Power to Remove Members | Article 39

### DIFF
--- a/CHARTER.md
+++ b/CHARTER.md
@@ -162,7 +162,7 @@ If a council is off-boarded:
 * Funds earmarked as working capital and for the completion incentive are returned to the Treasury
 
 ### Article 39
-A council can vote to remove any of its council members with a two-thirds majority vote. The Assembly and ATOM stakers cannot remove a council member directly.
+A council can vote to remove any of its council members with a two-thirds majority vote. The Assembly can vote to remove a member of any of its councils with a two-thirds majority vote. ATOM stakers cannot remove a council member directly.
 
 ### Article 40
 A council’s budget will be streamed wherever possible, meaning that the funds are released continuously over a predetermined period of time.


### PR DESCRIPTION
The community has no teeth when it comes to keeping councils accountable. While Atom stakers may remove councils, unless there are redundancies for whole councils, stakers would be damaging their own bottomline. Therefore, they would be disincentivised to remove whole councils except in the most extreme circumstances. With this indispensability and with work relationships on the line, councils could then "protect their own" with little to no consequences.

There are community members that want to give Atom stakers the power to remove individual members. However, community members do not have the time to keep up with Cosmos drama, and may not be fully informed on recent events. As such, they may be manipulated by misinformation as we have seen during the Juno Whale saga. In addition, the nature of online, decentralised participation may detach voters from the reality that they are dealing with an actual person's reputation and livelihood.

A reasonable compromise would be to give the Assembly the power to remove individual council members, with a two-thirds majority. The reasoning behind this is that other councils within the Assembly (including the Community Council as the representative for the wider Hub governance body) would have a more tangible relationship with the council member in question, and would be more tuned in to the facts of the case. Hence, they would be in a better position to make this decision.

Note: Added new sentence because "A council or The Assembly can vote to remove any of its council members with a two-thirds majority vote." Sounds like the Assembly removing a whole council